### PR TITLE
Gestion des date et heure (i18n)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,3 @@
+[Params]
+  month_label = ["Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"]
+  day_label = ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"]

--- a/layouts/event/single.html
+++ b/layouts/event/single.html
@@ -4,15 +4,15 @@
     <div>
             <span>Date :</span>
             {{ if ge .Date now }}
-            <span class="event-information">{{ .Date.Format "Monday 2 January 2006" }}</span>
+            <span class="event-information">{{ partial "datefull.html" . }}</span>
             {{ else }}
-            {{ $eventTime :=  .Date.Format "15:04" }}
-            <span title="Heure: {{ $eventTime }}" class="event-information">{{ .Date.Format "Monday 2 January 2006" }}</span>
+            {{ $eventTime :=  .Date.Format "15h04" }}
+            <span title="Heure: {{ $eventTime }}" class="event-information">{{ partial "datefull.html" . }}</span>
             {{ end }}
     </div>
     {{ if ge .Date now }}
     <div>
-            <span>Heure :</span><span class="event-information">{{ .Date.Format "15:04" }}</span>
+            <span>Heure :</span><span class="event-information">{{ .Date.Format "15h04" }}</span>
     </div>
     {{ end }}
     <div>
@@ -29,6 +29,8 @@
     </div>
     
 </div>
+
+
 <h5 class="event-title">Détails</h5>
 <div class="event">
     {{ .Content }}

--- a/layouts/partials/datefull.html
+++ b/layouts/partials/datefull.html
@@ -1,0 +1,14 @@
+{{ .Scratch.Set "month" "" }}
+{{ if isset .Site.Params "month_label" }}
+{{ .Scratch.Set "month" (index .Site.Params.month_label (sub (int (printf "%d" .Date.Month)) 1)) }}
+{{ else }}
+{{ .Scratch.Set "month" .Date.Month }}
+{{ end }}
+{{ .Scratch.Set "weekday" "" }}
+{{ if isset .Site.Params "day_label" }}
+{{ .Scratch.Set "weekday" (index .Site.Params.day_label (sub (int (printf "%d" ((time .Date).Weekday))) 1)) }}
+{{ else }}
+{{ .Scratch.Set "weekday" ( .Date.Format "Monday" ) }}
+{{ end }}
+
+{{ .Scratch.Get "weekday" }} {{ .Date.Day }} {{ .Scratch.Get "month" }} {{ .Date.Year }}

--- a/layouts/partials/datemonth.html
+++ b/layouts/partials/datemonth.html
@@ -1,0 +1,7 @@
+{{ .Scratch.Set "month" "" }}
+{{ if isset .Site.Params "month_label" }}
+{{ .Scratch.Set "month" (index .Site.Params.month_label (sub (int (printf "%d" .Date.Month)) 1)) }}
+{{ else }}
+{{ .Scratch.Set "month" .Date.Month }}
+{{ end }}
+{{ .Date.Day }} {{ .Scratch.Get "month" }}

--- a/layouts/partials/datemonthyear.html
+++ b/layouts/partials/datemonthyear.html
@@ -1,0 +1,7 @@
+{{ .Scratch.Set "month" "" }}
+{{ if isset .Site.Params "month_label" }}
+{{ .Scratch.Set "month" (index .Site.Params.month_label (sub (int (printf "%d" .Date.Month)) 1)) }}
+{{ else }}
+{{ .Scratch.Set "month" .Date.Month }}
+{{ end }}
+{{ .Date.Day }} {{ .Scratch.Get "month" }} {{ .Date.Year }}

--- a/layouts/partials/event-title-text.html
+++ b/layouts/partials/event-title-text.html
@@ -1,8 +1,8 @@
 <span>{{ .Title }}</span>
 <span class="event-date">
     {{ if lt .Date now }}
-    {{ .Date.Format "02 January" }}
+    {{ partial "datemonth.html" . }}
     {{ else }}
-        {{ .Date.Format "02 January 2006" }}
+    {{ partial "datemonthyear.html" . }}
     {{ end }}
 </span>

--- a/layouts/speaker/single.html
+++ b/layouts/speaker/single.html
@@ -12,7 +12,7 @@
             <div class="title no-margin sublist">
                     <span>{{ .Title }}</span>
                     <span class="event-date">
-                            {{ .Date.Format "02 January 2006" }}
+                                {{ partial "datemonthyear.html" . }}
                     </span>
             </div>
         </div>


### PR DESCRIPTION
**Dates**

Déclaration d'un fichier de configuration pour le theme comprenant 2 tableaux (jour de la semaine et mois) traduit en français, ce qui pourra être surcharger dans la configuration du site.

Et mise en place de 3 partial :

* datefull.html
* datemonth.html
* datemonthyear.html

Et modification des affichage de date pour faire appel à un de ces partial

**Heure**

Passage de l'affichage `19:30` à '19h30`