### PR TITLE
After : ajout de la section after

### DIFF
--- a/archetypes/after.md
+++ b/archetypes/after.md
@@ -1,0 +1,5 @@
+---
+title: "{{ lower .Name | urlize  }}" # Id de l'after d'une conférence - Id qui sera utilisé sous sa forme urlize pour être affiché dans la page d'une conférence au niveau de la section after (la page de conférence devra alimenter le champ after avec cet id urlizé)
+date: {{ .Date }} # date d'ajout
+# afterTitle: "" # Titre de la section after, si non défini, cela sera "After"
+---

--- a/archetypes/event.md
+++ b/archetypes/event.md
@@ -11,6 +11,7 @@ intro: "* Introduction pour l'evenement"
 # place: "" # emplacement de l'evenement
 # speakers: [] # Tableau avec les nom des speakers entre " et séparé par des , et doit être identique au titre du speaker enregistré !
 # docs: [[]] # Tableau donnant les liens vers les documents de la soirée hors affiche - exemple : [["L'inauguration","http://toursjug.cloud.xwiki.com/xwiki/bin/download/Meetings/20080409/InaugurationToursJUG.pdf"], ["Unitils et Selenium","Unitils-Selenium.pdf"]]
-# eventbrite : "" # Id de l'inscription (la partie de l'URL sr trouvant après https://www.eventbrite.fr/e/ )
+# eventbrite: "" # Id de l'inscription (la partie de l'URL sr trouvant après https://www.eventbrite.fr/e/ )
+# after: "" # Id (title urlizé d'un after) utilisé pour peupler la section after d'un evvent (exemple : apside-after-01)
 ---
 

--- a/layouts/event/single.html
+++ b/layouts/event/single.html
@@ -2,13 +2,13 @@
 <h2>{{ .Title }}</h2>
 <div class="event-info">
     <div>
-            <span>Date :</span>
-            {{ if ge .Date now }}
-            <span class="event-information">{{ partial "datetimeformated.html" . }}</span>
-            {{ else }}
-            {{ $eventTime :=  .Date.Format "15h04" }}
-            <span title="Heure: {{ $eventTime }}" class="event-information">{{ partial "datefull.html" . }}</span>
-            {{ end }}
+        <span>Date :</span>
+        {{ if ge .Date now }}
+        <span class="event-information">{{ partial "datetimeformated.html" . }}</span>
+        {{ else }}
+        {{ $eventTime :=  .Date.Format "15h04" }}
+        <span title="Heure: {{ $eventTime }}" class="event-information">{{ partial "datefull.html" . }}</span>
+        {{ end }}
     </div>
     <!--
     {{ if ge .Date now }}
@@ -18,35 +18,35 @@
     {{ end }}
     -->
     <div>
-            <span>Lieu :</span>
-            {{ if isset .Params "place" }}
-            <span class="event-information">
-                {{ $eventPlace := urlize .Params.place }}
-                {{ .Scratch.Set "placeFound" "" }}
-                {{ range where .Site.Pages "Section" "place" }}
-                {{ range .Pages }}
-                {{ if eq $eventPlace (urlize .Title) }}
-                {{ $.Scratch.Set "placeFound" .Permalink }}
-                {{ end }}
-                {{ end }}
-                {{ end }}
-                {{ if ne (.Scratch.Get "placeFound") "" }}
-                <a href="{{ .Scratch.Get "placeFound" }}">{{ .Params.place }}</a>
-                {{ else }}
-                {{ .Params.place }}
-                {{ end }}
-            </span>
-            {{ else }}
-            <span class="event-information undefined">
-                non défini
-            </span>
+        <span>Lieu :</span>
+        {{ if isset .Params "place" }}
+        <span class="event-information">
+            {{ $eventPlace := urlize .Params.place }}
+            {{ .Scratch.Set "placeFound" "" }}
+            {{ range where .Site.Pages "Section" "place" }}
+            {{ range .Pages }}
+            {{ if eq $eventPlace (urlize .Title) }}
+            {{ $.Scratch.Set "placeFound" .Permalink }}
             {{ end }}
+            {{ end }}
+            {{ end }}
+            {{ if ne (.Scratch.Get "placeFound") "" }}
+            <a href="{{ .Scratch.Get "placeFound" }}">{{ .Params.place }}</a>
+            {{ else }}
+            {{ .Params.place }}
+            {{ end }}
+        </span>
+        {{ else }}
+        <span class="event-information undefined">
+            non défini
+        </span>
+        {{ end }}
     </div>
     {{ if ge .Date now }}
     {{ if isset .Params "eventbrite" }}
     <div class="susbcribe open">
         {{ $link := (print "https://www.eventbrite.fr/e/" .Params.eventbrite ) }}
-        <a href="{{ $link }}" target="_blank" >Inscrivez vous !</a>
+        <a href="{{ $link }}" target="_blank">Inscrivez vous !</a>
     </div>
     {{else}}
     <div>
@@ -75,10 +75,31 @@
 <div>
     <span>
         <span class="speaker-title">Intervenant{{ if gt (len .Params.speakers) 1  }}s{{ end }} :</span>
-        <span class="speaker-list">{{ range .Params.speakers }}<span>{{ if in $a . }}{{ $speakerPath := print "speaker/" (urlize .) | absURL }}<a href="{{ $speakerPath }}">{{- . -}}</a>{{ else }}{{- . -}}{{ end }}</span>{{ end }}</span>
+        <span class="speaker-list">{{ range .Params.speakers }}<span>{{ if in $a . }}{{ $speakerPath := print "speaker/" (urlize .) | absURL }}<a
+                    href="{{ $speakerPath }}">{{- . -}}</a>{{ else }}{{- . -}}{{ end }}</span>{{ end }}</span>
     </span>
 </div>
 {{ end }}
+
+{{ if and (ge .Date now) (isset .Params "after") }}
+{{ $afterId := .Params.after }}
+{{ .Scratch.Set "afterId" .Params.after }}
+{{ range where .Site.Pages "Section" "after" }}
+{{ range first 1 (where .Pages "after-title" "eq" (.Scratch.Get "afterId")) }}
+<div>
+    <h5 class="event-title">
+        {{ if isset .Params "aftertitle" }}
+        {{ .Params.afterTitle }}
+        {{ else }}
+        After
+        {{ end }}
+    </h5>
+    {{ .Content }}
+</div>
+{{ end }}
+{{ end }}
+{{ end }}
+
 
 {{ if .Params.docs }}
 {{ $permalink := .Permalink }}
@@ -86,11 +107,11 @@
 <ul class="document">
     {{ range .Params.docs }}
     <li>
-            {{ if (hasPrefix (index . 1) "http") }}
-            <img src="/images/css/open_in_browser-24px.svg">
-            {{ else }}
-            <img src="/images/css/file_copy-24px.svg">
-            {{ end }}
+        {{ if (hasPrefix (index . 1) "http") }}
+        <img src="/images/css/open_in_browser-24px.svg">
+        {{ else }}
+        <img src="/images/css/file_copy-24px.svg">
+        {{ end }}
         <a href="{{ if not (hasPrefix (index . 1) "http") }}{{ $permalink }}{{ end }}{{ index . 1 }}">
             {{ index . 0 }}
         </a>


### PR DESCRIPTION
* archetype `after.md` permettant l'ajout d'un type d'after (exemple : `hugo new after/apside-after-01.md`)
* ajout du champ `after`pour les evenements ou sera stocké le title (id) de l'after d'un event
* modification de la vue single d'un event pour ajouter la section after si l'evenement n'est pas passé et que le champs after contient l'id d'une page existante