### PR TITLE
Ajout de l'incrustation d'une vidéo Youtube

### DIFF
--- a/archetypes/event.md
+++ b/archetypes/event.md
@@ -14,5 +14,6 @@ hideSpeaker: false
 # docs: [[]] # Tableau donnant les liens vers les documents de la soirée hors affiche - exemple : [["L'inauguration","http://toursjug.cloud.xwiki.com/xwiki/bin/download/Meetings/20080409/InaugurationToursJUG.pdf"], ["Unitils et Selenium","Unitils-Selenium.pdf"]]
 # eventbrite: "" # Id de l'inscription (la partie de l'URL sr trouvant après https://www.eventbrite.fr/e/ )
 # after: "" # Id (title urlizé d'un after) utilisé pour peupler la section after d'un evvent (exemple : apside-after-01)
+# youtube: "" # URL de la vidéo de la conférence
 ---
 

--- a/layouts/event/single.html
+++ b/layouts/event/single.html
@@ -123,4 +123,14 @@
     {{ end }}
 </ul>
 {{ end }}
+
+{{ if .Params.youtube }}
+<h5 class="event-title">La vidéo</h5>
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+    <iframe src="https://www.youtube.com/embed/{{ .Params.youtube }}?autoplay=1"
+        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" allowfullscreen
+        title="YouTube Video"></iframe>
+</div>
+{{ end }}
+
 {{ end }}

--- a/layouts/shortcodes/youtube.html
+++ b/layouts/shortcodes/youtube.html
@@ -1,0 +1,5 @@
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+        <iframe src="https://www.youtube.com/embed/{{ index .Params 0 }}?autoplay=1"
+            style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" allowfullscreen
+            title="YouTube Video"></iframe>
+    </div>


### PR DESCRIPTION
Si le paramètre youtube d'un event est affecté avec l'id de la vidéo, alors une section Vidéo est afficher.

exemple, pour récupérer l'id de la vidéo :

`https://youtu.be/nbIW9OYyZrI` --> ici l'Id de la vidéo est **nbIW9OYyZrI**

Et ajout d'un shortcode ayant le même effet, appel :
`{{< youtube nbIW9OYyZrI >}}`